### PR TITLE
allow non-nullable field argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- Allow non-nullable field argument
 
 ## [0.2.2] - 2024-01-26
 ### Added

--- a/src/Schema/Definition/Arguments/FieldArgument.php
+++ b/src/Schema/Definition/Arguments/FieldArgument.php
@@ -22,6 +22,8 @@ class FieldArgument
     protected bool $isDefaultValueSet = false;
 
     protected bool $multi = false;
+    
+    protected bool $nullable = true;
 
     public function __construct(string $name, Type $type)
     {
@@ -90,6 +92,23 @@ class FieldArgument
     public function setMulti(bool $multi = true): self
     {
         $this->multi = $multi;
+        return $this;
+    }
+
+    public function isNullable(): bool
+    {
+        return $this->nullable;
+    }
+
+    public function setNullable(bool $nullable = true): FieldArgument
+    {
+        $this->nullable = $nullable;
+        return $this;
+    }
+
+    public function setNonNullable(bool $nonNullable = true): FieldArgument
+    {
+        $this->nullable = !$nonNullable;
         return $this;
     }
 }

--- a/src/Schema/Transformers/WebonyxSchemaTransformer.php
+++ b/src/Schema/Transformers/WebonyxSchemaTransformer.php
@@ -190,6 +190,10 @@ final class WebonyxSchemaTransformer
             $argumentType = WebonyxType::listOf($argumentType);
         }
 
+        if (!$fieldArgument->isNullable()) {
+            $argumentType = WebonyxType::nonNull($argumentType);
+        }
+
         $argumentResult = [
             'name' => $fieldArgument->getName(),
             'type' => $argumentType,


### PR DESCRIPTION
Allow non-nullable field argument
```php
$argument = (new FieldArgument('argument', new IntType()))
  ->setNonNullable(); // or setNullable(false)
$field = (new Field('name', new StringType()))
  ->addArgument($argument);
```
