### PR TITLE
PHP 8.4 compatibility: explicit nullable parameter types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- PHP 8.4 compatibility: explicit nullable parameter types in `GraphQLException::__construct()` (implicit nullable is deprecated since PHP 8.4)
 
 ## [0.2.3] - 2024-02-28
 ### Added

--- a/src/Exceptions/GraphQLException.php
+++ b/src/Exceptions/GraphQLException.php
@@ -10,7 +10,7 @@ abstract class GraphQLException extends Exception implements ClientAware
 {
     protected ?Throwable $debugException = null;
 
-    public function __construct($message = "", $code = 0, Throwable $debugException = null, Throwable $previous = null)
+    public function __construct($message = "", $code = 0, ?Throwable $debugException = null, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $this->debugException = $debugException;


### PR DESCRIPTION
Implicit nullable parameter types are deprecated since PHP 8.4. This declares `?Throwable` explicitly in `GraphQLException::__construct()` (`$debugException`, `$previous`) — the only spot in the package flagged by Rector's `ExplicitNullableParamTypeRector`.

No behavioral change; the `php` constraint (`^7.4|^8.0`) already allows 8.4.